### PR TITLE
Expand find to include application and tags

### DIFF
--- a/src/main/java/seedu/internbuddy/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/internbuddy/logic/commands/FindCommand.java
@@ -8,14 +8,16 @@ import seedu.internbuddy.model.Model;
 import seedu.internbuddy.model.company.NameContainsKeywordsPredicate;
 
 /**
- * Finds and lists all companies in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Finds and lists all companies in address book whose name, tags or application details
+ * contains any of the argument keywords.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all companies whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all companies whose names, tags or"
+            + "application details contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";

--- a/src/main/java/seedu/internbuddy/model/company/Company.java
+++ b/src/main/java/seedu/internbuddy/model/company/Company.java
@@ -99,6 +99,30 @@ public class Company {
         return Collections.unmodifiableList(applications);
     }
 
+    public String getAppNameString() {
+        StringBuilder appNames = new StringBuilder();
+        for (Application application : applications) {
+            appNames.append(application.getName().fullName).append(" ");
+        }
+        return appNames.toString();
+    }
+
+    public String getTagsString() {
+        StringBuilder tagNames = new StringBuilder();
+        for (Tag tag : tags) {
+            tagNames.append(tag.tagName).append(" ");
+        }
+        return tagNames.toString();
+    }
+
+    public String getAppDescriptionString() {
+        StringBuilder appDescriptions = new StringBuilder();
+        for (Application application : applications) {
+            appDescriptions.append(application.getDescription().fullDescription).append(" ");
+        }
+        return appDescriptions.toString();
+    }
+
     /**
      * Returns true if both companies have the same name.
      * This defines a weaker notion of equality between two companies.

--- a/src/main/java/seedu/internbuddy/model/company/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/internbuddy/model/company/NameContainsKeywordsPredicate.java
@@ -19,7 +19,11 @@ public class NameContainsKeywordsPredicate implements Predicate<Company> {
     @Override
     public boolean test(Company company) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(company.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(company.getName().fullName, keyword)
+                || StringUtil.containsWordIgnoreCase(company.getTagsString(), keyword)
+                || (company.getApplications() != null
+                        && (StringUtil.containsWordIgnoreCase(company.getAppNameString(), keyword)
+                        || StringUtil.containsWordIgnoreCase(company.getAppDescriptionString(), keyword))));
     }
 
     @Override

--- a/src/test/java/seedu/internbuddy/model/company/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/internbuddy/model/company/NameContainsKeywordsPredicateTest.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.internbuddy.model.application.Application;
+import seedu.internbuddy.testutil.ApplicationBuilder;
 import seedu.internbuddy.testutil.CompanyBuilder;
 
 public class NameContainsKeywordsPredicateTest {
@@ -60,6 +62,94 @@ public class NameContainsKeywordsPredicateTest {
     }
 
     @Test
+    public void test_tagsContainsKeywords_returnsTrue() {
+        NameContainsKeywordsPredicate predicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("EV"));
+        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon, Musk, EV").build()));
+
+        // Multiple keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Elon", "Musk"));
+        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon, Musk, EV").build()));
+
+        // Only one matching keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Zuckerberg", "Elon"));
+        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon, Musk, EV").build()));
+
+        // Mixed-case keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("mUsK", "eV"));
+        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon, Musk, EV").build()));
+
+        // Matches both name and tag
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Musk", "EV", "Tesla"));
+        assertTrue(predicate.test(new CompanyBuilder().withName("Tesla").withTags("Elon, Musk, EV").build()));
+    }
+
+    @Test
+    public void test_appNameContainsKeywords_returnsTrue() {
+        Application sweApplication = new ApplicationBuilder().withName("SWE").build();
+        Application aiApplication = new ApplicationBuilder().withName("AI").build();
+        NameContainsKeywordsPredicate predicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("SWE"));
+        assertTrue(predicate.test(new CompanyBuilder().withApplications(sweApplication, aiApplication).build()));
+
+        // Multiple keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("SWE", "AI"));
+        assertTrue(predicate.test(new CompanyBuilder().withApplications(sweApplication, aiApplication).build()));
+
+        // Only one matching keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("AI", "Elon"));
+        assertTrue(predicate.test(new CompanyBuilder().withApplications(sweApplication, aiApplication).build()));
+
+        // Mixed-case keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("sWe", "aI"));
+        assertTrue(predicate.test(new CompanyBuilder().withApplications(sweApplication, aiApplication).build()));
+    }
+
+    @Test
+    public void test_appDescriptionContainsKeywords_returnsTrue() {
+        Application experienceApplication = new ApplicationBuilder()
+                .withDescription("Minimum 10 years experience").build();
+        Application noExperienceApplication = new ApplicationBuilder()
+                .withDescription("No job experience required").build();
+
+        NameContainsKeywordsPredicate predicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("years"));
+        assertTrue(predicate.test(new CompanyBuilder()
+                .withApplications(experienceApplication, noExperienceApplication).build()));
+
+        // Multiple keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("years", "experience"));
+        assertTrue(predicate.test(new CompanyBuilder()
+                .withApplications(experienceApplication, noExperienceApplication).build()));
+
+        // Only one matching keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("AI", "required"));
+        assertTrue(predicate.test(new CompanyBuilder()
+                .withApplications(experienceApplication, noExperienceApplication).build()));
+
+        // Mixed-case keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("reQuiRed", "jOB"));
+        assertTrue(predicate.test(new CompanyBuilder()
+                .withApplications(experienceApplication, noExperienceApplication).build()));
+    }
+
+    @Test
+    public void test_tagsDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new CompanyBuilder().withTags("EV").build()));
+
+        // Non-matching keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Innovations"));
+        assertFalse(predicate.test(new CompanyBuilder().withTags("AI").build()));
+
+        // Keywords match phone, email and address, but does not match tags
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "contact@techcorp.com", "Main", "Street"));
+        assertFalse(predicate.test(new CompanyBuilder().withPhone("12345")
+                .withEmail("contact@techcorp.com").withAddress("Main Street").withTags("AI").build()));
+    }
+
+    @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
         NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
@@ -73,6 +163,48 @@ public class NameContainsKeywordsPredicateTest {
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "contact@techcorp.com", "Main", "Street"));
         assertFalse(predicate.test(new CompanyBuilder().withName("TechCorp").withPhone("12345")
                 .withEmail("contact@techcorp.com").withAddress("Main Street").build()));
+    }
+
+    @Test
+    public void test_appNameDoesNotContainKeywords_returnsFalse() {
+        Application pgpApplication = new ApplicationBuilder().withName("PGP").build();
+        Application sgApplication = new ApplicationBuilder().withName("SG").build();
+
+        // Zero keywords
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new CompanyBuilder().withApplications(pgpApplication, sgApplication).build()));
+
+        // Non-matching keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Innovations"));
+        assertFalse(predicate.test(new CompanyBuilder().withApplications(pgpApplication, sgApplication).build()));
+
+        // Keywords match phone, email and address, but does not match application name
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "contact@techcorp.com", "Main", "Street"));
+        assertFalse(predicate.test(new CompanyBuilder().withPhone("12345").withEmail("contact@techcorp.com")
+                .withAddress("Main Street").withApplications(pgpApplication).build()));
+    }
+
+    @Test
+    public void test_appDescriptionDoesNotContainKeywords_returnsFalse() {
+        Application experienceApplication = new ApplicationBuilder()
+                .withDescription("Minimum 10 years experience").build();
+        Application noExperienceApplication = new ApplicationBuilder()
+                .withDescription("No job experience required").build();
+
+        // Zero keywords
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new CompanyBuilder()
+                .withApplications(experienceApplication, noExperienceApplication).build()));
+
+        // Non-matching keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Innovations"));
+        assertFalse(predicate.test(new CompanyBuilder()
+                .withApplications(experienceApplication, noExperienceApplication).build()));
+
+        // Keywords match phone, email and address, but does not match application name
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "contact@techcorp.com", "Main", "Street"));
+        assertFalse(predicate.test(new CompanyBuilder().withPhone("12345").withEmail("contact@techcorp.com")
+                .withAddress("Main Street").withApplications(experienceApplication).build()));
     }
 
     @Test

--- a/src/test/java/seedu/internbuddy/model/company/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/internbuddy/model/company/NameContainsKeywordsPredicateTest.java
@@ -65,23 +65,23 @@ public class NameContainsKeywordsPredicateTest {
     public void test_tagsContainsKeywords_returnsTrue() {
         NameContainsKeywordsPredicate predicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("EV"));
-        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon, Musk, EV").build()));
+        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon", "Musk", "EV").build()));
 
         // Multiple keywords
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Elon", "Musk"));
-        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon, Musk, EV").build()));
+        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon", "Musk", "EV").build()));
 
         // Only one matching keyword
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Zuckerberg", "Elon"));
-        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon, Musk, EV").build()));
+        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon", "Musk", "EV").build()));
 
         // Mixed-case keywords
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("mUsK", "eV"));
-        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon, Musk, EV").build()));
+        assertTrue(predicate.test(new CompanyBuilder().withTags("Elon", "Musk", "EV").build()));
 
         // Matches both name and tag
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Musk", "EV", "Tesla"));
-        assertTrue(predicate.test(new CompanyBuilder().withName("Tesla").withTags("Elon, Musk, EV").build()));
+        assertTrue(predicate.test(new CompanyBuilder().withName("Tesla").withTags("Elon", "Musk", "EV").build()));
     }
 
     @Test


### PR DESCRIPTION
Searching by company name only will not yield many functional results.

Expanding the find command to include words in application description and tags can help users search for companies in the company list more effectively.

This is done by expanding the test method in NameContainsKeywordsPredicate to include company application name, description and tags.