### PR TITLE
Edit JsonSerializableAddressBookTest to camelCase

### DIFF
--- a/src/test/java/seedu/internbuddy/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/internbuddy/storage/JsonSerializableAddressBookTest.java
@@ -25,8 +25,8 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_COMPANIES_FILE,
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
-        AddressBook typicalcompaniesAddressBook = TypicalCompanies.getTypicalAddressBook();
-        assertEquals(addressBookFromFile, typicalcompaniesAddressBook);
+        AddressBook typicalCompaniesAddressBook = TypicalCompanies.getTypicalAddressBook();
+        assertEquals(addressBookFromFile, typicalCompaniesAddressBook);
     }
 
     @Test


### PR DESCRIPTION
`typicalCompaniesAddressBook` was initially `typicalcompaniesAddressBook`. Edited it to maintain camelCase naming convention.