### PR TITLE
Remove AddressBook Level-3 reference and redundant Tutorials

### DIFF
--- a/docs/_markbind/layouts/default.md
+++ b/docs/_markbind/layouts/default.md
@@ -40,10 +40,6 @@
   * [Documentation, logging, testing, configuration, dev-ops]({{ baseUrl }}/DeveloperGuide.html#documentation-logging-testing-configuration-dev-ops)
   * [Appendix: Requirements]({{ baseUrl }}/DeveloperGuide.html#appendix-requirements)
   * [Appendix: Instructions for manual testing]({{ baseUrl }}/DeveloperGuide.html#appendix-instructions-for-manual-testing)
-* Tutorials
-  * [Tracing code]({{ baseUrl }}/tutorials/TracingCode.html)
-  * [Adding a command]({{ baseUrl }}/tutorials/AddRemark.html)
-  * [Removing Fields]({{ baseUrl }}/tutorials/RemovingFields.html)
 * [About Us]({{ baseUrl }}/AboutUs.html)
       </site-nav>
     </div>

--- a/docs/site.json
+++ b/docs/site.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "",
   "titlePrefix": "InternBuddy",
-  "titleSuffix": "AddressBook Level-3",
+  "titleSuffix": "Your Internship Buddy",
   "faviconPath": "images/InternBuddyLogo.png",
   "style": {
     "codeTheme": "light"


### PR DESCRIPTION
# Remove previously missed AddressBook Level-3 References and redundant Tutorials
* Removed AddressBook Level-3 Reference from site.json titleSuffix that was previously missed.
* Removed Tutorials from Site Map as they were no longer relevant to the project.
* Resolves #180 and #182